### PR TITLE
Allow dot (and perhaps other characters) in username

### DIFF
--- a/taiga_contrib_ldap_auth/services.py
+++ b/taiga_contrib_ldap_auth/services.py
@@ -41,9 +41,8 @@ def ldap_register(username: str, email: str, full_name: str):
         user = user_model.objects.get(username=username)
     except user_model.DoesNotExist:
         # Create a new user
-        username_unique = slugify_uniquely(username, user_model, slugfield="username")
         user = user_model.objects.create(email=email,
-                                         username=username_unique,
+                                         username=username,
                                          full_name=full_name)
         user_registered_signal.send(sender=user.__class__, user=user)
 


### PR DESCRIPTION
Removed slugify_uniquely method for the username since this led to
username being different from the LDAP DB.